### PR TITLE
Default camera view

### DIFF
--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -22,7 +22,7 @@
 	const axes = persisted('axes', true)
 
 	$: object = $selectedObject
-	$: component= $position === 'inline' ? Inline : Draggable
+	$: component = $position === 'inline' ? Inline : Draggable
 </script>
 
 <Portal>

--- a/src/lib/components/Internal/CameraControls.svelte
+++ b/src/lib/components/Internal/CameraControls.svelte
@@ -2,20 +2,19 @@
 	context="module"
 	lang="ts"
 >
+	import CameraControls from 'camera-controls'
 	import {
+		Box3,
+		MathUtils,
+		Matrix4,
+		Quaternion,
+		Raycaster,
+		Sphere,
+		Spherical,
 		Vector2,
 		Vector3,
 		Vector4,
-		Quaternion,
-		Matrix4,
-		Spherical,
-		Box3,
-		Sphere,
-		Raycaster,
-		MathUtils,
-		Clock,
 	} from 'three'
-	import CameraControls from 'camera-controls'
 
 	CameraControls.install({
 		THREE: {
@@ -34,19 +33,17 @@
 </script>
 
 <script lang="ts">
-	import { onDestroy } from 'svelte'
 	import { useTask, useThrelte } from '@threlte/core'
+	import { onDestroy } from 'svelte'
 	import { getInternalContext } from '../../internal/context'
 
 	export let camera: THREE.PerspectiveCamera | THREE.OrthographicCamera
 
 	const { renderer } = useThrelte()
 	const { usingTransformControls } = getInternalContext()
-	const clock = new Clock()
 	const cameraControls = new CameraControls(camera, renderer.domElement)
 
-	useTask(() => {
-		const delta = clock.getDelta()
+	useTask((delta) => {
 		cameraControls.update(delta)
 	})
 

--- a/src/lib/components/Positions/Draggable.svelte
+++ b/src/lib/components/Positions/Draggable.svelte
@@ -6,9 +6,10 @@
 	import Bindings from '../Bindings/Bindings.svelte'
 	import Tools from '../Tools/Tools.svelte'
 	import Perf from '../Internal/Perf.svelte'
+	import DefaultCameraView from '../Tools/DefaultCameraView.svelte'
 
 	const { theme } = useInspector()
-	const { selectedObject } = getInternalContext()
+	const { selectedObject, usingFreeCamera } = getInternalContext()
 
 	$: object = $selectedObject
 </script>
@@ -24,20 +25,20 @@
 	y={6}
 >
 	{#if $$slots.default}
-	<TabGroup>
-		<TabPage title='inspector'>
-			<Element>
-				<Tools />
-			</Element>
-	
-			<Separator />
-	
-			<Element>
-				<Tree />
-			</Element>
-		</TabPage>
-		<slot />
-	</TabGroup>
+		<TabGroup>
+			<TabPage title="inspector">
+				<Element>
+					<Tools />
+				</Element>
+
+				<Separator />
+
+				<Element>
+					<Tree />
+				</Element>
+			</TabPage>
+			<slot />
+		</TabGroup>
 	{:else}
 		<Element>
 			<Tools />
@@ -80,5 +81,24 @@
 		{#key object}
 			<Bindings {object} />
 		{/key}
+	</Pane>
+{/if}
+
+{#if $usingFreeCamera}
+	<Pane
+		title="Default Camera"
+		position="draggable"
+		theme={ThemeUtils.presets[$theme]}
+		localStoreId="three-inspect-pane-game-view"
+		storePositionLocally
+		userExpandable={false}
+		width={308}
+		x={browser ? window.innerWidth - 6 - 308 : 6}
+		y={browser ? window.innerHeight - 6 - 196 : 6}
+	>
+		<DefaultCameraView
+			width={300}
+			height={160}
+		/>
 	</Pane>
 {/if}

--- a/src/lib/components/Tools/DefaultCameraView.svelte
+++ b/src/lib/components/Tools/DefaultCameraView.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	import { useTask, useThrelte } from '@threlte/core'
+	import { Element } from 'svelte-tweakpane-ui'
+	import { Camera, OrthographicCamera, PerspectiveCamera, Vector2, Vector4 } from 'three'
+	import { getInternalContext } from '../../internal/context'
+
+	export let width = 160
+	export let height = 90
+
+	const { autoRenderTask, renderer, scene } = useThrelte()
+	const { defaultCamera } = getInternalContext()
+
+	let canvasEl: HTMLCanvasElement
+
+	$: context = canvasEl?.getContext('2d') ?? undefined
+
+	let previousAspect = 0
+	const setupPerspectiveCamera = (camera: PerspectiveCamera) => {
+		previousAspect = camera.aspect
+		// set up perspective cam to be 16/9
+		camera.aspect = width / height
+		camera.updateProjectionMatrix()
+	}
+
+	let previousLeft = 0
+	let previousRight = 0
+	const updateOrthographicCamera = (camera: OrthographicCamera) => {
+		// set up ortho cam to be 16/9
+		const frustumHeight = camera.top - camera.bottom
+		const aspect = width / height
+		previousLeft = camera.left
+		previousRight = camera.right
+		camera.left = -frustumHeight * aspect
+		camera.right = frustumHeight * aspect
+		camera.updateProjectionMatrix()
+	}
+
+	const updateCamera = (camera: Camera) => {
+		if ((camera as any).isPerspectiveCamera) {
+			setupPerspectiveCamera(camera as PerspectiveCamera)
+		} else if ((camera as any).isOrthographicCamera) {
+			updateOrthographicCamera(camera as OrthographicCamera)
+		}
+	}
+
+	const resetPerspectiveCamera = (camera: PerspectiveCamera) => {
+		camera.aspect = previousAspect
+		camera.updateProjectionMatrix()
+	}
+
+	const resetOrthographicCamera = (camera: OrthographicCamera) => {
+		camera.left = previousLeft
+		camera.right = previousRight
+		camera.updateProjectionMatrix()
+	}
+
+	const resetCamera = (camera: Camera) => {
+		if ((camera as any).isPerspectiveCamera) {
+			resetPerspectiveCamera(camera as PerspectiveCamera)
+		} else if ((camera as any).isOrthographicCamera) {
+			resetOrthographicCamera(camera as OrthographicCamera)
+		}
+	}
+
+	const viewport = new Vector4()
+	const size = new Vector2()
+	let dpr = 0
+	useTask(
+		() => {
+			if (!context) return
+			if (!defaultCamera.current) return
+
+			updateCamera(defaultCamera.current)
+
+			renderer.getViewport(viewport)
+			renderer.getSize(size)
+
+			const setupCanvas = dpr === 0
+
+			dpr = renderer.getPixelRatio()
+
+			if (setupCanvas) {
+				canvasEl.width = width * dpr
+				canvasEl.height = height * dpr
+			}
+
+			// set viewport
+			renderer.setViewport(0, 0, width, height)
+
+			renderer.render(scene, defaultCamera.current)
+
+			// reset viewport
+			renderer.setViewport(viewport)
+
+			// draw to canvas
+			context.drawImage(
+				renderer.domElement,
+				0,
+				(size.y - height) * dpr,
+				width * dpr,
+				height * dpr,
+				0,
+				0,
+				width * dpr,
+				height * dpr
+			)
+
+			resetCamera(defaultCamera.current)
+		},
+		{
+			before: autoRenderTask,
+			autoInvalidate: false,
+		}
+	)
+</script>
+
+<Element>
+	<canvas
+		bind:this={canvasEl}
+		style="width: {width}px; height: {height}px;"
+	/>
+</Element>

--- a/src/lib/components/Tools/FreeCamera.svelte
+++ b/src/lib/components/Tools/FreeCamera.svelte
@@ -10,13 +10,22 @@
 </script>
 
 <script lang="ts">
+	import { T, useThrelte, watch } from '@threlte/core'
 	import { onDestroy } from 'svelte'
-	import { T, useThrelte } from '@threlte/core'
 	import CameraControls from '../Internal/CameraControls.svelte'
+	import { getInternalContext } from '../../internal/context'
 
 	const { camera } = useThrelte()
-	const lastCamera = camera.current
+	const { defaultCamera } = getInternalContext()
 	const freeCamera = new THREE.PerspectiveCamera()
+
+	defaultCamera.set(camera.current)
+	watch(camera, (newCamera) => {
+		if (newCamera !== freeCamera) {
+			defaultCamera.set(newCamera)
+			camera.set(freeCamera)
+		}
+	})
 
 	freeCamera.position.copy(object.position)
 	freeCamera.quaternion.copy(object.quaternion)
@@ -24,7 +33,7 @@
 	onDestroy(() => {
 		object.position.copy(freeCamera.position)
 		object.quaternion.copy(freeCamera.quaternion)
-		camera.set(lastCamera)
+		if (defaultCamera.current) camera.set(defaultCamera.current)
 	})
 </script>
 

--- a/src/lib/internal/context.ts
+++ b/src/lib/internal/context.ts
@@ -9,6 +9,7 @@ const publicKey = Symbol('three-inspect-context')
 interface InternalContext {
 	usingTransformControls: CurrentWritable<boolean>
 	usingFreeCamera: CurrentWritable<boolean>
+	defaultCamera: CurrentWritable<THREE.Camera | undefined>
 	usingRaycast: CurrentWritable<boolean>
 	selectedObject: CurrentWritable<THREE.Object3D | undefined>
 }
@@ -27,6 +28,7 @@ export const setInternalContext = () => {
 	setContext<InternalContext>(internalKey, {
 		usingTransformControls: currentWritable(false),
 		usingFreeCamera: currentWritable(false),
+		defaultCamera: currentWritable(undefined),
 		usingRaycast: currentWritable(false),
 		selectedObject: currentWritable<THREE.Object3D | undefined>(undefined),
 	})

--- a/src/routes/test2/Scene.svelte
+++ b/src/routes/test2/Scene.svelte
@@ -7,10 +7,6 @@
 	const { scene, camera, renderer } = useThrelte()
 
 	scene.background = new THREE.Color('#222')
-	scene.add(camera.current)
-
-	camera.current.far = 300
-	camera.current.position.set(0, 2, 10)
 
 	const cubeTextureLoader = new THREE.CubeTextureLoader()
 
@@ -93,6 +89,13 @@
 <Inspector position="draggable" />
 
 <T.AmbientLight intensity={0.8} />
+
+<T.PerspectiveCamera
+	fov={80}
+	far={300}
+	position={[0, 2, 10]}
+	makeDefault
+/>
 
 <T.DirectionalLight
 	castShadow


### PR DESCRIPTION
Creates a "Default View" inspector pane on `draggable` inspector panes. If wanted, I can port that over to `inline`.

https://github.com/threlte/three-inspect/assets/46897060/8c94cc85-4ea1-4558-8974-f145cb210cec

